### PR TITLE
Feature/improve login and user management

### DIFF
--- a/lifemonitor/api/models/registries/registry.py
+++ b/lifemonitor/api/models/registries/registry.py
@@ -293,16 +293,16 @@ class WorkflowRegistry(auth_models.HostingService):
         'polymorphic_identity': 'workflow_registry'
     }
 
-    def __init__(self, registry_type, client_credentials, server_credentials):
-        super().__init__(server_credentials.api_base_url, name=server_credentials.name)
+    def __init__(self, registry_type, client_credentials, server_credentials, name: str = None):
+        super().__init__(server_credentials.api_base_url, name=name or server_credentials.name)
         self.registry_type = registry_type
         self.client_credentials = client_credentials
         self.server_credentials = server_credentials
         self._client = None
 
     def __repr__(self):
-        return '<WorkflowRegistry ({}) -- name {}, url {}>'.format(
-            self.uuid, self.name, self.uri)
+        return '<WorkflowRegistry ({}) -- name {}, client_name: {}, url {}>'.format(
+            self.uuid, self.name, self.client_name, self.uri)
 
     @property
     def api(self) -> auth_models.Resource:
@@ -460,6 +460,6 @@ class WorkflowRegistry(auth_models.HostingService):
         return cls.registry_types.get_class(registry_type)
 
     @classmethod
-    def new_instance(cls, registry_type, client_credentials, server_credentials):
+    def new_instance(cls, registry_type, client_credentials, server_credentials, name: str = None):
         return cls.get_registry_class(registry_type)(client_credentials,
-                                                     server_credentials)
+                                                     server_credentials, name=name)

--- a/lifemonitor/api/models/registries/registry.py
+++ b/lifemonitor/api/models/registries/registry.py
@@ -442,14 +442,18 @@ class WorkflowRegistry(auth_models.HostingService):
             raise lm_exceptions.LifeMonitorException(detail=str(e), stack=str(e))
 
     @classmethod
-    def find_by_name(cls, name):
+    def find_by_client_name(cls, name) -> WorkflowRegistry:
+        return cls.find_by_provider_client_name(name)
+
+    @classmethod
+    def find_by_name(cls, name) -> List[WorkflowRegistry]:
         try:
-            return cls.query.filter(WorkflowRegistry.name == name).one()
+            return cls.query.filter(WorkflowRegistry.name == name).all()
         except Exception as e:
             raise lm_exceptions.EntityNotFoundException(WorkflowRegistry, entity_id=name, exception=e)
 
     @classmethod
-    def find_by_uri(cls, uri):
+    def find_by_uri(cls, uri) -> WorkflowRegistry:
         try:
             return cls.query.filter(WorkflowRegistry.uri == uri).one()
         except Exception as e:

--- a/lifemonitor/api/models/registries/registry.py
+++ b/lifemonitor/api/models/registries/registry.py
@@ -162,7 +162,7 @@ class WorkflowRegistryClient(ABC):
     def __init__(self, registry: WorkflowRegistry):
         self._registry = registry
         try:
-            self._oauth2client: RemoteApp = getattr(oauth2_registry, self.registry.name)
+            self._oauth2client: RemoteApp = getattr(oauth2_registry, self.registry.client_name)
         except AttributeError:
             raise RuntimeError(f"Unable to find a OAuth2 client for the {self.registry.name} service")
 

--- a/lifemonitor/api/models/registries/seek.py
+++ b/lifemonitor/api/models/registries/seek.py
@@ -50,8 +50,8 @@ class SeekWorkflowRegistry(WorkflowRegistry):
         'polymorphic_identity': 'seek_registry'
     }
 
-    def __init__(self, client_credentials, server_credentials):
-        super().__init__('seek_registry', client_credentials, server_credentials)
+    def __init__(self, client_credentials, server_credentials, name: str = None):
+        super().__init__('seek_registry', client_credentials, server_credentials, name=name)
 
     @property
     def read_write_scopes(self) -> Tuple[str]:

--- a/lifemonitor/api/models/repositories/config.py
+++ b/lifemonitor/api/models/repositories/config.py
@@ -102,7 +102,7 @@ class WorkflowRepositoryConfig(RepositoryFile):
         for rfs in self._get_refs_list():
             for r in rfs.get("update_registries", []):
                 if not registries.get(r, None):
-                    registries[r] = models.WorkflowRegistry.find_by_name(r)
+                    registries[r] = models.WorkflowRegistry.find_by_client_name(r)
         return list(registries.values())
 
     def get_ref_registries(self, ref_type: str, tag: str) -> List[models.WorkflowRegistry]:
@@ -113,10 +113,10 @@ class WorkflowRepositoryConfig(RepositoryFile):
             registries = {}
             for r in tag_data.get("update_registries", []):
                 if not registries.get(r, None):
-                    registry = models.WorkflowRegistry.find_by_name(r)
+                    registry = models.WorkflowRegistry.find_by_client_name(r)
                     if not registry:
                         logger.warning("Unable to find registry: %r", r)
-                    registries[r] = models.WorkflowRegistry.find_by_name(r)
+                    registries[r] = models.WorkflowRegistry.find_by_client_name(r)
             return list(registries.values())
         except KeyError as e:
             logger.debug("KeyError: %r", str(e))

--- a/lifemonitor/api/services.py
+++ b/lifemonitor/api/services.py
@@ -489,7 +489,7 @@ class LifeMonitor:
     @staticmethod
     def get_workflow_registry_by_name(registry_name) -> models.WorkflowRegistry:
         try:
-            r = models.WorkflowRegistry.find_by_name(registry_name)
+            r = models.WorkflowRegistry.find_by_client_name(registry_name)
             if not r:
                 raise lm_exceptions.EntityNotFoundException(models.WorkflowRegistry, registry_name)
             return r

--- a/lifemonitor/auth/controllers.py
+++ b/lifemonitor/auth/controllers.py
@@ -31,12 +31,11 @@ from lifemonitor.utils import (NextRouteRegistry, next_route_aware,
 from .. import exceptions
 from ..utils import OpenApiSpecs
 from . import serializers
-from .forms import (EmailForm, LoginForm,
-                    NotificationsForm, Oauth2ClientForm, RegisterForm,
-                    SetPasswordForm)
+from .forms import (EmailForm, LoginForm, NotificationsForm, Oauth2ClientForm,
+                    RegisterForm, SetPasswordForm)
 from .models import db
 from .oauth2.client.services import (get_current_user_identity, get_providers,
-                                     merge_users, save_current_user_identity)
+                                     save_current_user_identity)
 from .oauth2.server.services import server
 from .services import (authorized, current_registry, current_user,
                        delete_api_key, generate_new_api_key, login_manager)

--- a/lifemonitor/auth/controllers.py
+++ b/lifemonitor/auth/controllers.py
@@ -393,23 +393,29 @@ def update_github_registry_settings():
 @blueprint.route("/merge", methods=("GET", "POST"))
 @login_required
 def merge():
-    form = LoginForm(data={
-        "username": request.args.get("username"),
-        "provider": request.args.get("provider")})
-    if form.validate_on_submit():
-        user = form.get_user()
-        if user:
-            if user != current_user:
-                merge_users(current_user, user, request.args.get("provider"))
-                flash(
-                    "User {username} has been merged into your account".format(
-                        username=user.username
-                    )
-                )
-                return redirect(url_for("auth.index"))
-            else:
-                form.username.errors.append("Cannot merge with yourself")
-    return render_template("auth/merge.j2", form=form)
+    username = request.args.get("username")
+    provider = request.args.get("provider")
+    flash(f"Your <b>{provider}</b> identity is already linked to the username "
+          f"<b>{username}</b> and cannot be merged to <b>{current_user.username}</b>",
+          category="warning")
+    return redirect(url_for('auth.profile'))
+    # form = LoginForm(data={
+    #     "username": username,
+    #     "provider": provider})
+    # if form.validate_on_submit():
+    #     user = form.get_user()
+    #     if user:
+    #         if user != current_user:
+    #             merge_users(current_user, user, request.args.get("provider"))
+    #             flash(
+    #                 "User {username} has been merged into your account".format(
+    #                     username=user.username
+    #                 )
+    #             )
+    #             return redirect(url_for("auth.index"))
+    #         else:
+    #             form.username.errors.append("Cannot merge with yourself")
+    # return render_template("auth/merge.j2", form=form)
 
 
 @blueprint.route("/create_apikey", methods=("POST",))

--- a/lifemonitor/auth/controllers.py
+++ b/lifemonitor/auth/controllers.py
@@ -256,6 +256,17 @@ def logout():
     return redirect(url_for("auth.index"))
 
 
+@blueprint.route("/delete_account", methods=("POST",))
+@login_required
+def delete_account():
+    current_user.delete()
+    session.pop('_flashes', None)
+    flash("Your account has been deleted", category="success")
+    logout_user()
+    NextRouteRegistry.clear()
+    return redirect(url_for("auth.index"))
+
+
 @blueprint.route("/set_password", methods=("GET", "POST"))
 @login_required
 def set_password():

--- a/lifemonitor/auth/models.py
+++ b/lifemonitor/auth/models.py
@@ -393,8 +393,8 @@ class Resource(db.Model, ModelMixin):
         self.uuid = uuid
 
     def __repr__(self):
-        return '<Resource {}: {} -> {} (type={}))>'.format(
-            self.id, self.uuid, self.uri, self.type)
+        return '<{} {}: {} -> uri={} (type={}))>'.format(
+            self.__class__.__name__, self.id, self.uuid, self.uri, self.type)
 
     @hybrid_property
     def authorizations(self):

--- a/lifemonitor/auth/oauth2/client/controllers.py
+++ b/lifemonitor/auth/oauth2/client/controllers.py
@@ -186,7 +186,7 @@ class AuthorizatonHandler:
                     if current_user != identity.user:
                         # Account collision! Ask user if they want to merge accounts.
                         return redirect(url_for(self.merge_view,
-                                                provider=identity.provider,
+                                                provider=identity.provider.client_name,
                                                 username=identity.user.username))
                 # If the user is logged in and the token is unlinked or linked yet,
                 # link the token to the current user

--- a/lifemonitor/auth/oauth2/client/controllers.py
+++ b/lifemonitor/auth/oauth2/client/controllers.py
@@ -216,11 +216,11 @@ class AuthorizatonHandler:
                 # link the token to the current user
                 identity.user = current_user
                 identity.save()
-                flash(f"Your account has successfully been linked to the identity {identity}.")
+                flash(f"Your account has successfully been linked to your <b>{identity.provider.name}</b> identity.")
 
             # Determine the right next hop
             next_url = NextRouteRegistry.pop()
-            flash(f"Logged with your \"{provider.name.capitalize()}\" identity.", category="success")
+            flash(f"Logged with your <b>\"{identity.provider.name}\"</b> identity.", category="success")
             return redirect(next_url, code=307) if next_url \
                 else RequestHelper.response() or redirect('/', code=302)
 

--- a/lifemonitor/auth/oauth2/client/controllers.py
+++ b/lifemonitor/auth/oauth2/client/controllers.py
@@ -117,7 +117,7 @@ class AuthorizatonHandler:
         # avoid autoflush in this session
         with db.session.no_autoflush:
             try:
-                p = OAuth2IdentityProvider.find(provider.name)
+                p = OAuth2IdentityProvider.find_by_client_name(provider.name)
                 logger.debug("Provider found: %r", p)
             except exceptions.EntityNotFoundException:
                 try:

--- a/lifemonitor/auth/oauth2/client/models.py
+++ b/lifemonitor/auth/oauth2/client/models.py
@@ -131,7 +131,7 @@ class OAuthIdentity(models.ExternalServiceAccessAuthorization, ModelMixin):
         # where the dictionary key is the OAuth provider name.
         backref=db.backref(
             "oauth_identity",
-            collection_class=attribute_mapped_collection("provider.name"),
+            collection_class=attribute_mapped_collection("provider.client_name"),
             cascade="all, delete-orphan",
         ),
     )

--- a/lifemonitor/auth/oauth2/client/models.py
+++ b/lifemonitor/auth/oauth2/client/models.py
@@ -265,11 +265,18 @@ class OAuth2Registry(OAuth):
         return self._clients.values()
 
     def register_client(self, client_config):
-        class OAuth2Client(FlaskRemoteApp):
-            NAME = client_config.name
-            OAUTH_APP_CONFIG = client_config.oauth_config
+        client_name = None
+        try:
+            client_name = client_config.client_name
+        except AttributeError:
+            client_name = client_config.name
 
-        super().register(client_config.name, overwrite=True, client_cls=OAuth2Client)
+        class OAuth2Client(FlaskRemoteApp):
+            NAME = client_name
+            OAUTH_APP_CONFIG = client_config.oauth_config
+        if not client_name:
+            raise RuntimeWarning(f"Unable to configure {client_config}: missing 'name' or 'client_name'")
+        super().register(client_name, overwrite=True, client_cls=OAuth2Client)
 
     def is_initialized(self) -> bool:
         return self._initialized

--- a/lifemonitor/auth/oauth2/client/models.py
+++ b/lifemonitor/auth/oauth2/client/models.py
@@ -441,7 +441,7 @@ class OAuth2IdentityProvider(db.Model, ModelMixin):
             raise OAuthIdentityNotFoundException(f"{provider_user_id}@{self}")
 
     @classmethod
-    def find(cls, name) -> OAuth2IdentityProvider:
+    def find_by_name(cls, name) -> OAuth2IdentityProvider:
         try:
             return cls.query.filter(cls.name == name).one()
         except NoResultFound:
@@ -453,6 +453,13 @@ class OAuth2IdentityProvider(db.Model, ModelMixin):
             return cls.query.filter(cls.client_name == client_name).one()
         except NoResultFound:
             raise EntityNotFoundException(cls, entity_id=client_name)
+
+    @classmethod
+    def find_by_client_id(cls, client_id) -> List[OAuth2IdentityProvider]:
+        try:
+            return cls.query.filter(cls.client_id == client_id).all()
+        except NoResultFound:
+            raise EntityNotFoundException(cls, entity_id=client_id)
 
     @classmethod
     def find_by_uri(cls, uri) -> OAuth2IdentityProvider:

--- a/lifemonitor/auth/oauth2/client/providers/github.py
+++ b/lifemonitor/auth/oauth2/client/providers/github.py
@@ -53,10 +53,12 @@ def normalize_userinfo(client, data):
 
 
 class GitHub:
-    name = 'github'
+    name = 'Github'
+    client_name = 'github'
     oauth_config = {
         'client_id': current_app.config.get('GITHUB_CLIENT_ID', None),
         'client_secret': current_app.config.get('GITHUB_CLIENT_SECRET', None),
+        'client_name': client_name,
         'uri': 'https://github.com',
         'api_base_url': 'https://api.github.com',
         'access_token_url': 'https://github.com/login/oauth/access_token',

--- a/lifemonitor/auth/oauth2/client/services.py
+++ b/lifemonitor/auth/oauth2/client/services.py
@@ -93,7 +93,7 @@ def merge_users(merge_from: User, merge_into: User, provider: str):
 
 def save_current_user_identity(identity: OAuthIdentity):
     session["oauth2_username"] = identity.user.username if identity else None
-    session["oauth2_provider_name"] = identity.provider.name if identity else None
+    session["oauth2_provider_name"] = identity.provider.client_name if identity else None
     session["oauth2_user_info"] = identity.user_info if identity else None
     session["oauth2_user_token"] = identity.token if identity else None
     logger.debug("User identity temporary save: %r", identity)

--- a/lifemonitor/auth/oauth2/client/services.py
+++ b/lifemonitor/auth/oauth2/client/services.py
@@ -104,7 +104,7 @@ def get_current_user_identity():
         provider_name = session.get("oauth2_provider_name")
         user_info = session.get("oauth2_user_info")
         token = session.get("oauth2_user_token")
-        p = OAuth2IdentityProvider.find(provider_name)
+        p = OAuth2IdentityProvider.find_by_client_name(provider_name)
         logger.debug("Provider found: %r", p)
         identity = OAuthIdentity(
             provider=p,

--- a/lifemonitor/auth/templates/auth/account_tab.j2
+++ b/lifemonitor/auth/templates/auth/account_tab.j2
@@ -29,7 +29,7 @@
         {% if p.client_name in current_user.oauth_identity %}
         <td>
             {% if current_user.oauth_identity|length > 1 or current_user.has_password %}
-            <a href="/oauth2/logout/{{p.client_name}}" title="Click to unlink your '{{p.client_name}}' identity">
+            <a title="Click to unlink your '{{p.client_name}}' identity" onclick="disconnect('{{p.name}}', '{{p.client_name}}')">
                 <span class="badge bg-success" style="width: 75px; margin-right: 5px;">CONNECTED</span>
                 <i class="fas fa-link fa-xs" style="color: black;"></i>
             </a>
@@ -83,4 +83,19 @@
 </div>
 {% endif %}
 
-
+<script>
+    function disconnect(providerName, providerClientName){
+        showInputDialog({
+            //image: 'logo',
+            iconClass: "fas fa-unlink",
+            question: `Disconnect <br> '${providerName}' identity?`,
+            description: `Your <b>'${providerName}'</b> identity will disconnected <br>from your account. Are you sure you want to continue?`,
+            confirmText: "Disconnect",
+            cancelText: "Cancel",
+            onConfirm: function(){
+                alert("ok");
+                document.location.href = `/oauth2/logout/${providerClientName}`;
+            }
+        });
+    }
+</script>

--- a/lifemonitor/auth/templates/auth/account_tab.j2
+++ b/lifemonitor/auth/templates/auth/account_tab.j2
@@ -77,11 +77,37 @@
         {{ macros.render_custom_field(passwordForm.repeat_password) }}
     </div>
     <div class="form-group pt-5 text-center">
-        <button type="submit" class="btn btn-primary text-bold" style="width: 120px">Update</button>
+        <button type="submit" class="btn btn-primary text-bold" style="width: 175px">Update</button>
     </div>
     </form>
 </div>
 {% endif %}
+
+<div class="card-header">
+    <h3 class="card-title"><b>Delete Account</b></h3>
+</div>
+
+<div class="card-body">
+    <div class="text-muted pt-2 pb-2">
+        {%if current_user.workflows|length == 0%}
+        No workflow associated with your account.
+        {%else%}
+        Your account is associated with {{current_user.workflows|length}} 
+        workflow{%if current_user.workflows|length>1%}s{%endif%}.<br>
+        If you delete your account, all your workflows will be deleted 
+        and you will not be able to recover them.
+        {%endif%}
+    </div>
+    <form id="deleteAccount" method="POST" action="{{ url_for('auth.delete_account') }}" >
+    {{ passwordForm.hidden_tag() }}
+    <div class="form-group pt-5 text-center">
+        <button type="button" onclick="deleteAccount()"
+                class="btn btn-danger text-bold" style="width: 175px">
+                Delete your account
+        </button>
+    </div>
+    </form>
+</div>
 
 <script>
     function disconnect(providerName, providerClientName){
@@ -94,6 +120,24 @@
             cancelText: "Cancel",
             onConfirm: function(){
                 document.location.href = `/oauth2/logout/${providerClientName}`;
+            }
+        });
+    }
+    
+    function deleteAccount(){
+        showInputDialog({
+            //image: 'logo',
+            iconClass: "fas fa-user-alt-slash",
+            question: `Delete your account?`,
+            description: `Your <b>'{{current_user.username}}'</b> account and 
+            {%if current_user.workflows|length == 1%} your workflow
+            {%elif current_user.workflows|length > 1 %} your <em>{{current_user.workflows|length}} workflows</em>
+            {%endif%} will be deleted. <br>Are you sure you want to continue?`,
+            confirmText: "Delete",
+            confirmButtonClass: "btn-danger",
+            cancelText: "Cancel",
+            onConfirm: function(){
+                $("#deleteAccount").submit();
             }
         });
     }

--- a/lifemonitor/auth/templates/auth/account_tab.j2
+++ b/lifemonitor/auth/templates/auth/account_tab.j2
@@ -22,16 +22,16 @@
     {% for p in providers %}
         <tr>
         <td>{{ macros.render_provider_fa_icon(p, color="black") }}</td>
-        <td>{{p.name.capitalize()}}</td>
-        <td>{% if p.name in current_user.oauth_identity %}
-            {{ current_user.oauth_identity[p.name].provider_user_id }}
+        <td>{{p.name}}</td>
+        <td>{% if p.client_name in current_user.oauth_identity %}
+            {{ current_user.oauth_identity[p.client_name].provider_user_id }}
             {% endif %}</td>
-        {% if p.name in current_user.oauth_identity %}
+        {% if p.client_name in current_user.oauth_identity %}
         <td><span class="badge bg-success">CONNECTED</span></td>
         {% else %}
         <td>
             <span class="badge bg-primary">
-            <a class="" href="/oauth2/login/{{p.name}}">CONNECT</a>
+            <a class="" href="/oauth2/login/{{p.client_name}}">CONNECT</a>
             </span>
         </td>
         {% endif %}

--- a/lifemonitor/auth/templates/auth/account_tab.j2
+++ b/lifemonitor/auth/templates/auth/account_tab.j2
@@ -93,7 +93,6 @@
             confirmText: "Disconnect",
             cancelText: "Cancel",
             onConfirm: function(){
-                alert("ok");
                 document.location.href = `/oauth2/logout/${providerClientName}`;
             }
         });

--- a/lifemonitor/auth/templates/auth/account_tab.j2
+++ b/lifemonitor/auth/templates/auth/account_tab.j2
@@ -15,7 +15,7 @@
         <th style="width: 5px"></th>
         <th>Provider</th>
         <th style="width: 100px">User ID</th>
-        <th style="width: 40px"></th>
+        <th style="width: 120px"></th>
         </tr>
     </thead>
     <tbody>
@@ -27,12 +27,23 @@
             {{ current_user.oauth_identity[p.client_name].provider_user_id }}
             {% endif %}</td>
         {% if p.client_name in current_user.oauth_identity %}
-        <td><span class="badge bg-success">CONNECTED</span></td>
-        {% else %}
         <td>
-            <span class="badge bg-primary">
-            <a class="" href="/oauth2/login/{{p.client_name}}">CONNECT</a>
-            </span>
+            {% if current_user.oauth_identity|length > 1 or current_user.has_password %}
+            <a href="/oauth2/logout/{{p.client_name}}" title="Click to unlink your '{{p.client_name}}' identity">
+                <span class="badge bg-success" style="width: 75px; margin-right: 5px;">CONNECTED</span>
+                <i class="fas fa-link fa-xs" style="color: black;"></i>
+            </a>
+            {% else %}
+            <span class="badge bg-success" style="width: 75px; margin-right: 5px;">CONNECTED</span>
+            {% endif %}
+
+        </td>
+        {% else %}
+        <td>            
+            <a href="/oauth2/login/{{p.client_name}}" title="Click to link your '{{p.client_name}}' identity">
+                <span class="badge bg-primary" style="width: 75px; margin-right: 5px;">CONNECT</span>
+                <i class="fas fa-unlink fa-xs" style="color: black;"></i>                
+            </a>
         </td>
         {% endif %}
         </tr>

--- a/lifemonitor/auth/templates/auth/apikeys_tab.j2
+++ b/lifemonitor/auth/templates/auth/apikeys_tab.j2
@@ -62,10 +62,10 @@
                 </button>
             </td>
             <td>
-            <form method="POST"
+            <form id="deleteApiKey{{k.key}}" method="POST"
                     action="{{ url_for('auth.delete_apikey') }}">
                 <input type="hidden" name="apikey" value="{{k.key}}" />
-                <button class="btn btn-link" type="submit" style="padding: 0">
+                <button class="btn btn-link" type="button" style="padding: 0" onclick=deleteApiKey('{{k.key}}')>
                 <span class="badge bg-danger">
                 DELETE
                 </span>
@@ -77,3 +77,26 @@
         </tbody>
     </table>
 </div>
+
+
+<script>
+    function deleteApiKey(key){
+        showInputDialog({
+            //image: 'logo',
+            iconClass: "fas fa-key",
+            question: `Delete API key?`,
+            description: `Your API key <b class="apikey">'****${key.substring(key.length-15)}'</b> will be deleted from your account. Are you sure you want to continue?`,
+            confirmText: "Delete",
+            confirmButtonClass: 'btn-danger',
+            cancelText: "Cancel",
+            onConfirm: function(){
+                const form = $(`#deleteApiKey${key}`);
+                if(form){
+                    form.submit();
+                }else{
+                    console.warning("Unable to find apiKey form");
+                }
+            }
+        });
+    }
+</script>

--- a/lifemonitor/auth/templates/auth/apikeys_tab.j2
+++ b/lifemonitor/auth/templates/auth/apikeys_tab.j2
@@ -7,7 +7,7 @@
     </div>
     <div class="col-sm-3 col-lg-2 d-block">    
         <div>
-            <a href="/openapi.html" title="LifeMonitor API Explorer">        
+            <a href="/openapi.html" title="LifeMonitor API Explorer" target="_blank">        
                 <div class="row">
                     <div class="col-12 text-center font-weight-light">
                         <img src="{{ url_for('auth.static', filename='img/logo/openapi-custom-colors.svg') }}" width="90px">    

--- a/lifemonitor/auth/templates/auth/base.j2
+++ b/lifemonitor/auth/templates/auth/base.j2
@@ -52,6 +52,9 @@
       style="{% block body_style %}{% endblock body_style %}">
   {% block body %}{% endblock %}
 
+  <!-- Include input pane dialog -->
+  {% include 'auth/input_dialog.j2' %}
+
   <!-- JS dependencies  -->
   {% block javascripts_libraries %}
     <!-- jQuery -->

--- a/lifemonitor/auth/templates/auth/input_dialog.j2
+++ b/lifemonitor/auth/templates/auth/input_dialog.j2
@@ -69,7 +69,7 @@
 
         // set onConfirm callback
         if (options.onConfirm) {
-            $('#inputDialogConfirm').on('click', ()=>{
+            $('#inputDialogConfirm').on('click', () => {
                 options.onConfirm();
             });
         }

--- a/lifemonitor/auth/templates/auth/input_dialog.j2
+++ b/lifemonitor/auth/templates/auth/input_dialog.j2
@@ -42,7 +42,6 @@
 
     function showInputDialog(options) {
         options = options || {};
-        console.log(options.title);
         $('#inputDialogTitle').html(options.title || '');
         if (!options.title) { $('#inputDialogTitleContainer').hide(); }
 
@@ -65,7 +64,9 @@
         $('#inputDialogClosePane').hide();
         $('#inputDialogConfirm').html(options.confirmText);
         if (!options.confirmText) $('#inputDialogConfirm').hide();
+        $('#inputDialogConfirm').attr("class", `btn ${options.confirmButtonClass || 'btn-primary'} btn-lg m-1`);
         $('#inputDialogCancel').html(options.cancelText || "Close");
+        $('#inputDialogCancel').attr("class", `btn ${options.cancelButtonClass || 'btn-secondary'} btn-lg m-1`);
 
         // set onConfirm callback
         if (options.onConfirm) {

--- a/lifemonitor/auth/templates/auth/input_dialog.j2
+++ b/lifemonitor/auth/templates/auth/input_dialog.j2
@@ -1,0 +1,81 @@
+<!-- Modal -->
+<div class="modal fade" id="inputDialog" tabindex="-1" role="dialog" aria-labelledby="inputDialog" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div id="inputDialogTitleContainer" class="modal-header text-center m-auto">
+                <h5 id="inputDialogTitle" class="modal-title" [innerHTML]="title"></h5>
+            </div>
+            <div class="modal-body">
+
+                <button id="inputDialogClosePane" type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+
+                <div id="inputDialogIconContainer" class="text-center p-5 text-primary">
+                    <i id="inputDialogIcon" class="{{iconClass}} {{iconClassSize}}"></i>
+                </div>
+
+                <div id="inputDialogImageContainer" class="text-center p-5 text-primary">
+                    <img id="inputDialogImage" src="{{iconImage}}" width="{{iconImageSize}}">
+                </div>
+
+                <div class="text-center">
+                    <h2 id="inputDialogQuestion" clas="font-weight-light" [innerHTML]="question"></h2>
+                    <h6 id="inputDialogDescription" class="text-muted mt-5" [innerHTML]="description"></h6>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <div class="col-md-12 text-center p-2">
+                    <button id="inputDialogCancel" type="button" class="btn btn-secondary btn-lg m-1"
+                        data-dismiss="modal" style="width: 125px;" [innerHTML]="cancelText">
+                    </button>
+                    <button id="inputDialogConfirm" type="button" class="btn btn-primary btn-lg m-1"
+                        style="width: 125px;" [innerHTML]="confirmText">
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+
+    function showInputDialog(options) {
+        options = options || {};
+        console.log(options.title);
+        $('#inputDialogTitle').html(options.title || '');
+        if (!options.title) { $('#inputDialogTitleContainer').hide(); }
+
+        // Set icon class if defined
+        $('#inputDialogIcon').attr('class', `${options.iconClass} ${options.iconSize || 'fa-5x'}`);
+        if (!options.iconClass) { $('#inputDialogIconContainer').hide(); }
+
+        // Set image if defined
+        $('#inputDialogImage').attr('src', options.image === 'logo' ? 'static/img/logo/lm/LifeMonitorLogo.png' : options.image);
+        $('#inputDialogImage').attr('width', options.imageWidth || 180);
+        $('#inputDialogImage').attr('length', options.imageLength);
+        if (!options.image) { $('#inputDialogImageContainer').hide(); }
+
+        // Set question
+        $('#inputDialogQuestion').html(options.question);
+        // Set description
+        $('#inputDialogDescription').html(options.description);
+
+        // controls
+        $('#inputDialogClosePane').hide();
+        $('#inputDialogConfirm').html(options.confirmText);
+        if (!options.confirmText) $('#inputDialogConfirm').hide();
+        $('#inputDialogCancel').html(options.cancelText || "Close");
+
+        // set onConfirm callback
+        if (options.onConfirm) {
+            $('#inputDialogConfirm').on('click', ()=>{
+                options.onConfirm();
+            });
+        }
+
+        // open dialog
+        $('#inputDialog').modal('show');
+    };
+
+</script>

--- a/lifemonitor/auth/templates/auth/macros.j2
+++ b/lifemonitor/auth/templates/auth/macros.j2
@@ -25,6 +25,8 @@
       <div>{{message}}</div>
     </div>
 </div>
+{% else %}
+<div>&nbsp;</div>
 {% endif %}
 {%- endmacro %}
 

--- a/lifemonitor/auth/templates/auth/macros.j2
+++ b/lifemonitor/auth/templates/auth/macros.j2
@@ -143,13 +143,13 @@
 
 
 {% macro render_provider_fa_icon(provider, color="white") -%}
-{% if provider.name == "github" %}
+{% if provider.client_name == "github" %}
 <i class="fab fa-github mr-2"></i>
 {% elif provider.type == "seek" %}
 {% if color == "white" %}
-<img style="width: 1.5em;"src="{{ url_for('auth.static', filename='img/logo/wfhub/workflowhub-128.png') }}" />
+<img style="width: 1.5em; margin-right: 5px;" src="{{ url_for('auth.static', filename='img/logo/wfhub/workflowhub-128.png') }}" />
 {% else %}
-<img style="width: 1em;"src="{{ url_for('auth.static', filename='img/logo/wfhub/workflowhub-128-black.png') }}" />
+<img style="width: 1em; margin-right: 5px;" src="{{ url_for('auth.static', filename='img/logo/wfhub/workflowhub-128-black.png') }}" />
 {% endif %}
 {% elif provider.type == "google" %}
 <i class="fab fa-google mr-2"></i>
@@ -158,10 +158,10 @@
 
 
 {% macro render_provider_logo(provider) -%}
-{% if provider.name == "github" %}
+{% if provider.client_name == "github" %}
 <img style="width: 8em;" src="{{ url_for('auth.static', filename='img/logo/providers/github.png') }}" />
 {% elif provider.type == "seek" %}
-<img style="width: 7em; margin-top: -10px;" src="{{ url_for('auth.static', filename='img/logo/providers/workflowhub.svg') }}" />
+<img style="width: 7em; margin-top: -10px; margin-right: 5px;" src="{{ url_for('auth.static', filename='img/logo/providers/workflowhub.svg') }}" />
 {% elif provider.type == "google" %}
 <img style="width: 8em; margin-top: -10px;" src="{{ url_for('auth.static', filename='img/logo/providers/google.png') }}" />
 {% endif %}
@@ -169,7 +169,7 @@
 
 
 {% macro render_provider_btn_class(provider) -%}
-{% if provider.name == "github" %}
+{% if provider.client_name == "github" %}
 btn-dark
 {% elif provider.type == "seek" %}
 btn-primary
@@ -179,13 +179,13 @@ btn-red
 {%- endmacro %}
 
 {% macro render_provider_signin_button(provider) -%}
-<a href="/oauth2/login/{{provider.name}}" class="btn btn-block {{render_provider_btn_class(provider)}}">
-  {{render_provider_fa_icon(provider)}} Sign in using {{provider.name.capitalize()}}
+<a href="/oauth2/login/{{provider.client_name}}" class="btn btn-block {{render_provider_btn_class(provider)}}">
+  {{render_provider_fa_icon(provider)}} Sign in with <b>{{provider.name}}</b>
 </a>
 {%- endmacro %}
 
 {% macro render_provider_signup_button(provider) -%}
-<a href="/oauth2/login/{{provider.name}}" class="btn btn-block {{render_provider_btn_class(provider)}}">
-  {{render_provider_fa_icon(provider)}} Sign up using {{provider.name.capitalize()}}
+<a href="/oauth2/login/{{provider.client_name}}" class="btn btn-block {{render_provider_btn_class(provider)}}">
+  {{render_provider_fa_icon(provider)}} Sign up with <b>{{provider.name}}</b>
 </a>
 {%- endmacro %}

--- a/lifemonitor/auth/templates/auth/oauth2_clients_tab.j2
+++ b/lifemonitor/auth/templates/auth/oauth2_clients_tab.j2
@@ -91,11 +91,11 @@
               </span>
             </button>
           </form>
-          <form method="POST"
+          <form id="deleteOAuth2Client_{{client.client_id}}" method="POST"
                 action="{{ url_for('auth.delete_generic_code_flow_client') }}">
             <input type="hidden" name="clientId" value="{{client.client_id}}" />
-            <button class="btn btn-link" type="submit" style="padding: 0"
-                    title="click to delete">
+            <button class="btn btn-link" type="button" style="padding: 0"
+                    title="click to delete" onclick="deleteClient('{{client.client_id}}','{{client.client_name}}')">
               <span class="badge bg-danger">
               DELETE
               </span>
@@ -108,3 +108,25 @@
   </table>
 </div>
 
+
+<script>
+  function deleteClient(clientId, clientName){
+      showInputDialog({
+          //image: 'logo',
+          iconClass: "fas fa-laptop-code",
+          question: `Delete OAuth2 Client?`,
+          description: `Your OAuth2 Client <b>'${clientName}'</b> will be deleted from your account. <br>Are you sure you want to continue?`,
+          confirmText: "Delete",
+          confirmButtonClass: 'btn-danger',
+          cancelText: "Cancel",
+          onConfirm: function(){
+              const form = $(`#deleteOAuth2Client_${clientId}`);
+              if(form){
+                  form.submit();
+              }else{
+                  console.warning("Unable to find oauth2Client form");
+              }
+          }
+      });
+  }
+</script>

--- a/lifemonitor/auth/templates/auth/oauth2_clients_tab.j2
+++ b/lifemonitor/auth/templates/auth/oauth2_clients_tab.j2
@@ -6,7 +6,7 @@
   </div>  
   <div class="col-sm-3 col-lg-2 d-block">    
         <div>
-            <a href="/openapi.html" title="LifeMonitor API Explorer">        
+            <a href="/openapi.html" title="LifeMonitor API Explorer" target="_blank">        
                 <div class="row">
                     <div class="col-12 text-center font-weight-light">
                         <img src="{{ url_for('auth.static', filename='img/logo/openapi-custom-colors.svg') }}" width="90px">    

--- a/lifemonitor/auth/templates/auth/profile.j2
+++ b/lifemonitor/auth/templates/auth/profile.j2
@@ -102,7 +102,7 @@
   {{ macros.render_logo(style="width: 50%") }}
 
   {{ macros.render_warning(
-      config.get("WARNING_MESSAGE", "None"),
+      config.get("WARNING_MESSAGE", None),
       classes="mt-5" if config.get('ENV') == 'production' else "")
   }}
 

--- a/lifemonitor/commands/registry.py
+++ b/lifemonitor/commands/registry.py
@@ -51,15 +51,16 @@ OAuth2 settings to connect to LifeMonitor:
 {'-'*100}
 REGISTRY NAME: {registry.name}
 REGISTRY API URL: {registry.uri}
+REGISTRY CLIENT NAME: {registry.client_name}
 REGISTRY CLIENT ID: {registry.client_credentials.client_id}
 REGISTRY CLIENT SECRET: {registry.client_credentials.client_secret}
 REGISTRY CLIENT ALLOWED SCOPES: {registry.client_credentials.client_metadata['scope']}
 REGISTRY CLIENT ALLOWED FLOWS: {registry.client_credentials.client_metadata['grant_types']}
 REGISTRY CLIENT REDIRECT URIs: {registry.client_credentials.redirect_uris}
 REGISTRY CLIENT AUTH METHOD: {registry.client_credentials.auth_method}
-AUTHORIZE URL: <LIFE_MONITOR_BASE_URL>/oauth2/authorize/{registry.name}
+AUTHORIZE URL: <LIFE_MONITOR_BASE_URL>/oauth2/authorize/{registry.client_name}
 ACCESS TOKEN URL: <LIFE_MONITOR_BASE_URL>/oauth2/token
-CALLBACK URL: <LIFE_MONITOR_BASE_URL>/oauth2/authorized/{registry.name}[?next=<URL>]
+CALLBACK URL: <LIFE_MONITOR_BASE_URL>/oauth2/authorized/{registry.client_name}[?next=<URL>]
 """
     print(output)
 
@@ -70,6 +71,8 @@ CALLBACK URL: <LIFE_MONITOR_BASE_URL>/oauth2/authorized/{registry.name}[?next=<U
 @click.argument("client-id")
 @click.argument("client-secret")
 @click.argument("api-url")
+@click.option("--client-name", default=None,
+              help="Short name which identifies the registry on LifeMonitor")
 @click.option("--redirect-uris", default=None,
               help="Redirect URIs (comma separated) to be used with authorization code flow")
 @click.option("--client-auth-method",
@@ -77,7 +80,7 @@ CALLBACK URL: <LIFE_MONITOR_BASE_URL>/oauth2/authorized/{registry.name}[?next=<U
               type=click.Choice(['client_secret_basic', 'client_secret_post']),
               default='client_secret_post')
 @with_appcontext
-def add_registry(name, type, client_id, client_secret, client_auth_method, api_url, redirect_uris):
+def add_registry(name, type, client_id, client_secret, client_auth_method, api_url, client_name, redirect_uris):
     """
     Add a new workflow registry and generate its OAuth2 credentials
     """
@@ -86,6 +89,7 @@ def add_registry(name, type, client_id, client_secret, client_auth_method, api_u
         # are associated with the admin account
         registry = lm.add_workflow_registry(type, name,
                                             client_id, client_secret,
+                                            client_name=client_name,
                                             client_auth_method=client_auth_method,
                                             api_base_url=api_url,
                                             redirect_uris=redirect_uris)
@@ -107,6 +111,8 @@ def add_registry(name, type, client_id, client_secret, client_auth_method, api_u
               help="OAuth2 Client ID to access to the registry")
 @click.option("--client-secret", default=None,
               help="OAuth2 Client Secret to access to the registry")
+@click.option("--client-name", default=None,
+              help="Short name which identifies the registry on LifeMonitor")
 @click.option("--api-url", default=None, help="Base URL of the registry")
 @click.option("--redirect-uris", default=None,
               help="Redirect URIs (comma separated) to be used with authorization code flow")
@@ -116,8 +122,8 @@ def add_registry(name, type, client_id, client_secret, client_auth_method, api_u
               default=None)
 @with_appcontext
 def update_registry(uuid, name,
-                    client_id, client_secret, client_auth_method,
-                    api_url, redirect_uris):
+                    client_id, client_secret, client_name,
+                    client_auth_method, api_url, redirect_uris):
     """
     Update a workflow registry
     """

--- a/lifemonitor/integrations/github/services.py
+++ b/lifemonitor/integrations/github/services.py
@@ -195,7 +195,7 @@ def register_workflow_on_registries(submitter: User, workflow: WorkflowVersion, 
     logger.debug("Registries map: %r", registries_map)
     for registry_name, workflow_identifier in registries_map:
         logger.debug("Registry: %r", registry_name)
-        registry: WorkflowRegistry = WorkflowRegistry.find_by_name(registry_name)
+        registry: WorkflowRegistry = WorkflowRegistry.find_by_client_name(registry_name)
         logger.debug("Registry: %r", registry)
         if registry:
             result.append(register_workflow_on_registry(submitter, workflow, workflow_identifier, registry))
@@ -206,7 +206,7 @@ def register_workflow_on_registry(submitter: User,
                                   workflow_version: WorkflowVersion, workflow_identifier: str,
                                   registry: Optional[str | WorkflowRegistry]):
     assert isinstance(registry, str) or isinstance(registry, WorkflowRegistry), registry
-    registry: WorkflowRegistry = WorkflowRegistry.find_by_name(registry) if isinstance(registry, str) else registry
+    registry: WorkflowRegistry = WorkflowRegistry.find_by_client_name(registry) if isinstance(registry, str) else registry
     logger.warning("Registry: %r", registry)
     if registry:
         try:
@@ -228,7 +228,7 @@ def delete_workflow_from_registries(submitter: User, workflow: WorkflowVersion, 
     logger.debug("Registries: %r", registries)
     for registry_name in registries:
         logger.debug("Registry: %r", registry_name)
-        registry: WorkflowRegistry = WorkflowRegistry.find_by_name(registry_name)
+        registry: WorkflowRegistry = WorkflowRegistry.find_by_client_name(registry_name)
         logger.debug("Registry: %r", registry)
         if registry:
             workflow_registry = workflow.registry_workflow_versions.get(registry.name, None)

--- a/tests/conftest_helpers.py
+++ b/tests/conftest_helpers.py
@@ -439,7 +439,7 @@ def create_client_credentials_registry(_app_settings, _admin_user, name='seek'):
 
 
 def get_registry(_app_settings, _admin_user) -> WorkflowRegistry:
-    registry = WorkflowRegistry.find_by_name("seek")
+    registry = WorkflowRegistry.find_by_client_name("seek")
     if registry is None:
         registry = create_client_credentials_registry(_app_settings, _admin_user)
     return registry

--- a/tests/integration/api/services/test_workflow_registry.py
+++ b/tests/integration/api/services/test_workflow_registry.py
@@ -56,7 +56,7 @@ def test_workflow_registry_registration_error_invalid_type(app_client,
     with pytest.raises(WorkflowRegistryNotSupportedException):
         LifeMonitor.get_instance().add_workflow_registry(
             "jenkins", random_string,
-            random_string, random_string, fake_uri)
+            random_string, random_string, api_base_url=fake_uri)
 
 
 def test_workflow_registry_registration_error_exists(app_client, provider_type,


### PR DESCRIPTION
* allow to use a "long format" name for providers and registries (e.g., "wfhubdev" --> "WorkflowHub (Dev) )

<p align="center">
<img src="https://user-images.githubusercontent.com/1832243/168830560-e9af4e71-fe18-43c6-864e-de5b852df079.png" height="600">
</p>

* Allow to disconnect (and reconnect) a user identity

<p align="center">
<img src="https://user-images.githubusercontent.com/1832243/168831249-c67d8aa7-78a9-40c5-9472-aa3fefe447b3.png" width="auto">
</p>

... with a proper message dialog to ask for confirmation:
<p align="center">
<img src="https://user-images.githubusercontent.com/1832243/168831785-f826233b-d603-45d0-9734-8bf379e2158a.png" width="400">
</div>


* Allow to delete a user account:

<p align="center">
<img src="https://user-images.githubusercontent.com/1832243/168833719-09b5d50e-6a22-4a2b-8927-b3877ba8a44f.png" with="400">
<img src="https://user-images.githubusercontent.com/1832243/168833614-3e997a38-85a6-4d5c-96ad-082f58696ee9.png" width="400">
</p>

* Ask for confirmation before deleting API Keys and OAuth2 clients:
<p align="center">
<img src="https://user-images.githubusercontent.com/1832243/168834209-b1e43968-ff60-4c8f-b899-fd636565d1b1.png" width="400">
<img src="https://user-images.githubusercontent.com/1832243/168834254-b48e897a-9593-4824-8bfd-b7ebc2499e24.png" width="400">
</p>
